### PR TITLE
Fix PEP 517/518 build isolation violation & broken dependency install

### DIFF
--- a/pyJHTDB/__init__.py
+++ b/pyJHTDB/__init__.py
@@ -66,8 +66,6 @@ else:
 auth_token = 'edu.jhu.pha.turbulence.testing-201406'
 homefolder = os.path.expanduser('~')
 lib_folder = os.path.join(homefolder, '.config/', 'JHTDB/')
-version_info = "20210108.0"
-version = str(version_info)
 
 # check if .config/JHTDB folder exists, create it if not
 #if os.path.isdir(lib_folder):

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,9 @@ AUTHOR_EMAIL = GROUP_EMAIL
 #      modified.
 #   2. VERSION should contain information on whether or not it depends
 #      on the hdf5 library, since that can't be installed through pip.
-#
-import pyJHTDB
-VERSION = pyJHTDB.version
+
+
+VERSION = '0.1.0'
 #if HDF5_ON:
 #    VERSION += '-hdf5'
 #


### PR DESCRIPTION
Importing `__version__` from `pyJHTDB.__init__.py` causes a circular dependency - loading pyJHTDB requires numpy but installing pyJHTDB & dependencies requires `__version__`.

Fixed by moving version string into `setup.py`